### PR TITLE
Fix required field validation logic for falsy payload values

### DIFF
--- a/stockManager/backend/common/decorators.py
+++ b/stockManager/backend/common/decorators.py
@@ -157,7 +157,20 @@ def validate_required_fields(required_fields: List[str]):
     def decorator(view_func):
         @functools.wraps(view_func)
         def wrapper(request, data, *args, **kwargs):
-            missing_fields = [field for field in required_fields if not data.get(field)]
+            missing_fields = []
+            for field in required_fields:
+                if field not in data:
+                    missing_fields.append(field)
+                    continue
+
+                value = data.get(field)
+                if value is None:
+                    missing_fields.append(field)
+                    continue
+
+                if isinstance(value, str) and value.strip() == '':
+                    missing_fields.append(field)
+
             if missing_fields:
                 return json_response(
                     status=ResponseStatus.ERROR,


### PR DESCRIPTION
### Motivation
- The original `validate_required_fields` used `not data.get(field)` which incorrectly treats valid falsy values like `0` or `False` as missing and causes unintended validation failures in JSON APIs.

### Description
- Adjusted `validate_required_fields` in `backend/common/decorators.py` to treat a field as missing only when the key is absent, the value is `None`, or the value is a blank string, while allowing numeric and boolean falsy values.
- No other behavioral changes were made outside this single validation improvement.

### Testing
- Ran `python3 manage.py check` which passed, producing only the existing staticfiles warning about the missing `front/dist` directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec3f6725c8328b85603a1f86651e2)