### PR TITLE
docs: add backend cache mechanism analysis

### DIFF
--- a/stockManager/backend/缓存机制分析.md
+++ b/stockManager/backend/缓存机制分析.md
@@ -1,0 +1,236 @@
+# Backend 缓存机制完整分析
+
+> 范围：`stockManager/backend` 目录下实际生效的缓存相关实现（键设计、数据内容、过期策略、失效策略、调用路径、代码结构）。
+
+## 1. 总览：缓存分层与职责
+
+当前后端缓存是一个 **两层结构**：
+
+1. **Django Cache（业务接口层）**
+   - 业务代码主要通过 `django.core.cache.cache` 读写缓存。
+   - 对象级读写、TTL、删除都在这一层完成。  
+2. **Redis 原生能力（优化层）**
+   - 在批量场景通过 `django_redis.get_redis_connection` 直连 Redis，利用 `MGET`、`pipeline`、`KEYS pattern` 提升性能或支持模式删除。
+
+对应代码分工：
+
+- `backend/services/cacheRepository.py`：**缓存仓库层（核心）**，定义 key、TTL、缓存策略、失效策略、业务读写入口。
+- `backend/common/cache.py`：**底层工具层**，封装批量读写和 pattern 删除，内置异常回退逻辑。
+- `backend/services/*`：**业务调用层**（收益计算、实时价格、股票名同步、股票元数据等）通过 `CacheRepository` 使用缓存。
+- `backend/views/stock.py`：提供管理员手动清理缓存接口。
+
+## 2. 基础配置：缓存后端与命名空间
+
+在 `settings.py` 中：
+
+- 后端使用 `django_redis.cache.RedisCache`。
+- `LOCATION` 来自环境变量 `REDIS_URL`。
+- 使用 `JSONSerializer` 作为序列化器。
+- 使用 `KEY_PREFIX='stockmanager'` 与 `VERSION=1` 做命名空间隔离。
+
+这会使最终 Redis key 形如：
+
+- `stockmanager:1:user:123:operations`
+- `stockmanager:1:stock:price:sh600519`
+
+这也是 `CacheRepository.get_stock_prices_batch` 手动拼接全 key 的原因之一（直接走 Redis `mget` 时需要完整 key）。
+
+## 3. 缓存内容清单（缓存什么）
+
+`CacheRepository` 定义了以下核心缓存对象：
+
+1. **用户操作流水**
+   - Key：`user:{user_id}:operations`
+   - 内容：按股票代码分组后的 `Operation` 列表（JSON 序列化后字符串）
+   - 用途：支撑操作列表查询、收益计算、分红生成。
+
+2. **用户现金信息**
+   - Key：`user:{user_id}:cash_info`
+   - 内容：
+     - `income_cash`（收益现金）
+     - `cash_flow_list`（现金流水列表）
+   - 用途：收益汇总计算。
+
+3. **用户计算结果（聚合结果）**
+   - Key：`user:{user_id}:calculated_target`
+   - 内容：`{"stocks": ..., "overall": ...}`
+   - 用途：`/api/stocks` 直接返回计算结果，避免重复计算。
+
+4. **股票元数据全量字典**
+   - Key：`stock:meta:all`
+   - 内容：`{code: {code,name,isNew,stockType}}`
+   - 用途：避免反复全表读取 `StockMeta`。
+
+5. **股票实时价格（单票）**
+   - Key：`stock:price:{code}`
+   - 内容：实时价格对象（name/currentPrice/priceOffset/offsetRatio/yesterdayClose）
+   - 用途：实时行情查询。
+
+6. **股票价格时间戳**
+   - Key：`stock:price:timestamp`
+   - 内容：ISO 时间字符串
+   - 用途：判断价格缓存是否应整体失效（是否跨过交易时段）。
+
+7. **股票名称日同步标记**
+   - Key：`stock:name:sync:daily`
+   - 内容：当日日期字符串（上海时区）
+   - 用途：限制“根据实时行情回写股票名称”每天最多执行一次。
+
+## 4. TTL 策略（各内容的过期策略）
+
+`CacheRepository` 常量：
+
+- `TTL_USER_DATA = 36000`（10 小时）
+- `TTL_CALCULATED_TARGET = 86400`（24 小时）
+- `TTL_STOCK_META = 86400`（24 小时）
+- `TTL_STOCK_PRICE = 86400`（24 小时）
+
+补充说明：
+
+- 日同步标记 `stock:name:sync:daily` 不是固定 TTL，而是“到次日 00:00 + 60 秒”，通过动态计算得到，确保自然日边界重置。
+- 尽管多个 key TTL 为 24h，但实际是否命中还受 **交易时段刷新规则** 影响（见下一节），即：逻辑失效早于物理过期。
+
+## 5. 刷新/失效策略（何时不使用缓存）
+
+### 5.1 交易时段驱动的“逻辑失效”
+
+关键函数：`CacheRepository._should_refresh_cache()`。
+
+- 若当前处于交易时段（`TradingCalendar.is_current_time_in_trading_hours()`），直接认为需要刷新，不使用“计算结果缓存”和“价格缓存”。
+- 若不在交易时段：
+  1. 读取 `stock:price:timestamp`
+  2. 如果无时间戳，刷新
+  3. 如果有时间戳，调用 `TradingCalendar.is_trading_time_passed(cached_time, now)` 判断两个时刻之间是否经历过交易时段；若经历过则刷新。
+
+这套机制解决了“TTL 还没过，但市场已经开盘/交易时段已变化，旧数据不应继续用”的问题。
+
+### 5.2 数据变更驱动的“主动失效”
+
+1. **用户维度数据变化**（`Operation`/`CashFlow`/`Info(INCOME_CASH)`）
+   - `integrate.py` 注册 `post_save/post_delete` 信号。
+   - 触发后执行 `CacheRepository.clear_user_cache(user_id)`，清除该用户：
+     - operations
+     - cash_info
+     - calculated_target
+
+2. **手动更新收益现金**
+   - `Integrate.update_income_cash` 更新 DB 后立即清用户缓存。
+
+3. **股票元数据变化**
+   - `stockMeta.py` 对 `StockMeta` 注册 `post_save/post_delete`。
+   - 变更后清除 `stock:meta:all`。
+
+4. **批量写入新价格后**
+   - `set_stock_prices_batch` 最后会更新 `stock:price:timestamp`。
+   - `set_stock_price_timestamp` 内部会调用 `clear_all_calculated_targets`，按 pattern 删除所有用户 `calculated_target`，避免价格变了但收益仍用旧缓存。
+
+5. **管理员全量清理**
+   - `POST /api/clearCache` -> `CacheRepository.clear_all()`。
+   - 按 `${KEY_PREFIX}:${VERSION}:*` 模式删除本应用缓存。
+
+## 6. 读写路径与命中行为
+
+### 6.1 用户操作与计算结果
+
+- `views/stock.py -> Integrate.get_calculated_result`：
+  1. 先查 `calculated_target`
+  2. 未命中则取 `operations` + `cash_info`
+  3. 调用 `Calculator` 计算
+  4. 回写 `calculated_target`（但交易时段内不会写）
+
+这意味着：
+
+- 高频接口 `/api/stocks` 主要依赖 `calculated_target` 命中。
+- 交易时段内为了实时性会强制走重算。
+
+### 6.2 实时价格
+
+- `RealtimePrice.query`：
+  1. `get_stock_prices_with_cache(code_list)` 返回 `(命中数据, 缺失列表)`
+  2. 对缺失股票调用 `easyquotation` API
+  3. 批量回写缓存并更新时间戳
+
+其中批量读写优化点：
+
+- 读：`Cache.get_many` -> Redis `MGET`
+- 写：`cache.set_many`（失败时降级逐条写）
+
+### 6.3 股票名称同步
+
+- `RealtimePrice.fetch_from_api` 默认 `sync_names=True`。
+- `StockNameSync.sync_from_realtime`：
+  - 若今日已同步过，直接跳过；
+  - 若有名称变化，`bulk_update` 后清 `stock:meta:all`，并写“今日已同步”标记。
+
+## 7. 底层工具与健壮性设计
+
+`backend/common/cache.py` 的三个工具方法体现了“性能优先 + 失败降级”：
+
+1. `get_many(keys)`
+   - 首选 Redis `mget`
+   - JSON 自动反序列化（字符串/bytes）
+   - 异常时回退为逐 key `cache.get`
+
+2. `set_many(mapping, timeout)`
+   - 首选 Redis pipeline 批量 `set ex=timeout`
+   - dict/list 自动 `json.dumps`
+   - 异常时回退为逐 key `cache.set`
+
+3. `delete_pattern(pattern)`
+   - 使用 Redis `keys + delete`
+   - 返回删除数量
+   - 异常时返回 0（保证主流程不抛出）
+
+> 注意：`KEYS` 在超大 keyspace 下可能阻塞，当前项目 key 规模可控时可接受；若未来规模增大可升级为 `SCAN` 迭代删除。
+
+## 8. 代码结构评估（优点与潜在风险）
+
+### 8.1 优点
+
+- **集中式缓存仓库**：key/TTL/策略统一在 `CacheRepository`，业务层调用简洁。
+- **实时性与性能平衡**：交易时段通过逻辑失效保证数据新鲜，非交易时段充分利用缓存。
+- **批量优化明确**：价格批量读写走 MGET/pipeline，减少 RTT。
+- **失效链完整**：用户数据、价格更新、元数据更新、管理员手动清理都覆盖。
+
+### 8.2 潜在风险与改进建议
+
+1. **硬编码全 key 前缀**
+   - `get_stock_prices_batch` 里写死 `stockmanager:1:`，与 `settings` 变更耦合。
+   - 建议统一通过 settings 动态拼接（已有 `clear_all` 这样做）。
+
+2. **pattern 删除使用 KEYS**
+   - 数据量大时可能阻塞 Redis。
+   - 建议改为 `SCAN` 分批删除。
+
+3. **Operation 手工反序列化构造 Model 对象**
+   - `_deserialize_operations` 使用 `Operation.__new__ + ModelState`，可用但维护成本高。
+   - 可考虑缓存 DTO（纯 dict）并在上层转换，降低 ORM 内部结构耦合。
+
+4. **异常吞噬较多**
+   - 若 Redis 异常频繁，当前策略偏“静默降级”。
+   - 建议增加指标埋点/告警（如回退次数、pattern 删除失败次数）。
+
+## 9. 一张表看懂缓存策略
+
+| 缓存项 | Key | TTL | 读取策略 | 失效策略 |
+|---|---|---:|---|---|
+| 用户操作 | `user:{id}:operations` | 10h | miss 查 DB 并缓存 | 用户相关模型 save/delete、手动更新收益现金 |
+| 用户现金信息 | `user:{id}:cash_info` | 10h | miss 查 DB 并缓存 | 同上 |
+| 用户计算结果 | `user:{id}:calculated_target` | 24h | 交易时段或跨交易时段直接视为失效；否则命中 | 用户数据变更；价格时间戳更新后按 pattern 全量清理 |
+| 股票元数据全量 | `stock:meta:all` | 24h | miss 查 DB 并缓存 | StockMeta save/delete；名称同步更新后清理 |
+| 股票实时价格 | `stock:price:{code}` | 24h | 批量命中+缺失回源 API | 逻辑上受交易时段判断约束；TTL 到期自然失效 |
+| 价格时间戳 | `stock:price:timestamp` | 24h | 用于判断是否跨交易时段 | 每次批量写价格时覆盖 |
+| 名称日同步标记 | `stock:name:sync:daily` | 到次日零点+60s | 控制每日最多同步一次 | 次日自然过期 |
+
+## 10. 关键代码入口索引
+
+- 缓存配置：`stockManager/settings.py`
+- 缓存仓库：`backend/services/cacheRepository.py`
+- Redis 批量工具：`backend/common/cache.py`
+- 交易时段判断：`backend/common/tradingCalendar.py`
+- 用户数据集成与信号失效：`backend/services/integrate.py`
+- 实时行情与价格缓存：`backend/services/realtimePrice.py`
+- 股票名称同步：`backend/services/stockNameSync.py`
+- 股票元数据缓存失效：`backend/services/stockMeta.py`
+- 管理员清缓存接口：`backend/views/stock.py`
+


### PR DESCRIPTION
### Motivation
- Provide a single, maintainable reference that explains the backend caching architecture, cached items, TTLs, invalidation rules and call paths to aid future maintenance and reduce onboarding time.

### Description
- Add `stockManager/backend/缓存机制分析.md` which documents cache layers, key naming and namespace, cached data types (user operations, cash info, calculated targets, stock meta, stock prices, timestamps and daily sync mark), TTL policies, and invalidation rules driven by trading hours and model signals.
- Include read/write paths, batch read/write optimizations (Redis MGET/pipeline), code entrypoint index, a one-table summary, and improvement suggestions (e.g., avoid hardcoded prefix, use SCAN for deletions, consider DTOs for operations).

### Testing
- Verified backend cache-related source files by reading `backend/common/cache.py`, `backend/services/cacheRepository.py`, `backend/services/realtimePrice.py`, `backend/services/stockNameSync.py`, `backend/services/stockMeta.py`, `backend/services/integrate.py`, `backend/common/tradingCalendar.py`, and `backend/views/stock.py` using `sed -n` to ensure the documentation aligns with code behavior.
- Confirmed the new document exists and its contents with file listing and `nl -ba stockManager/backend/缓存机制分析.md`, and validated that this is a documentation-only change with no runtime code modifications and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6be8c4bc8328b95fbdad9deeb9d7)